### PR TITLE
remove prism css

### DIFF
--- a/resources/views/inc/theme_styles.blade.php
+++ b/resources/views/inc/theme_styles.blade.php
@@ -3,7 +3,6 @@
 @basset('https://unpkg.com/animate.css@4.1.1/animate.compat.css')
 @basset('https://unpkg.com/noty@3.2.0-beta-deprecated/lib/noty.css')
 
-@basset('https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism.css')
 @basset('https://coreui.io/demos/bootstrap/4.2/free/vendors/simplebar/css/simplebar.css')
 @basset('https://coreui.io/demos/bootstrap/4.2/free/css/vendors/simplebar.css')
 @basset('https://coreui.io/demos/bootstrap/4.2/free/css/style.css')


### PR DESCRIPTION
I think this may be a leftover. 

We are not using prism.js here only css, so it's not working for sure anyway. 

It doesn't seem to have any impact. 