### PR TITLE
style-page-heading-section

### DIFF
--- a/resources/assets/css/coreui4.css
+++ b/resources/assets/css/coreui4.css
@@ -217,3 +217,8 @@ form .select2.select2-container.select2-container--open {
     padding: 1rem;
     border: var(--cui-border-width) var(--cui-border-style) var(--cui-border-color)!important;
 }
+
+h1[bp-section=page-heading] {
+    font-size: 2rem;
+    line-height: 2.1rem;
+}


### PR DESCRIPTION
In https://github.com/Laravel-Backpack/CRUD/pull/4931 we made all page headings `h1` instead of all across the board. And added an easy way to select it for styling. So let's do that - let's style the page-heading `h1` for all Backpack pages, in one place, for this theme.