### PR TITLE
add layout in theme config

### DIFF
--- a/config/theme-coreuiv4.php
+++ b/config/theme-coreuiv4.php
@@ -14,6 +14,10 @@ return [
     |
     */
 
+    // the layout used for authenticated users in the application
+    // this layout is used to display errors to logged users
+    'layout' => 'top_left',
+
     // -------
     // CLASSES
     // -------


### PR DESCRIPTION
As reported in https://github.com/Laravel-Backpack/CRUD/issues/5172 backpack would attempt to use the layout of the theme to display the errors to logged in users.

This theme don't have a `layout` so it will display without layout after https://github.com/Laravel-Backpack/CRUD/pull/5174 gets merged. At the moment it raises an error. 

Merging this would make this `layout` key available to be used in error views. 