### PR TITLE
Removed unnecessary source-sans-pro font

### DIFF
--- a/resources/views/inc/theme_styles.blade.php
+++ b/resources/views/inc/theme_styles.blade.php
@@ -1,9 +1,5 @@
 @basset('https://cdn.jsdelivr.net/npm/@coreui/coreui@4.2/dist/css/coreui.min.css')
 @basset('https://cdn.jsdelivr.net/npm/simplebar@6.2.5/dist/simplebar.min.css')
 
-{{-- Source Sans Font --}}
-@bassetArchive('https://github.com/adobe-fonts/source-sans/releases/download/3.046R/WOFF2-source-sans-3.046R.zip', 'source-sans-pro')
-@basset(base_path('vendor/backpack/theme-coreuiv4/resources/assets/libs/source-sans-pro.css'), 'source-sans-pro/source-sans-pro.css')
-
 {{-- Custom Backpack Rules --}}
 @basset(base_path('vendor/backpack/theme-coreuiv4/resources/assets/css/coreui4.css'))


### PR DESCRIPTION
CoreUI v4 no longer uses Source Sans 🎉

It uses:
```css
--cui-font-sans-serif: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
```